### PR TITLE
Experimenting with using `react-popper-tooltip` for tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-lazyload": "^2.3.0",
     "react-popper": "^1.3.0",
     "react-popper-tooltip": "^2.7.0",
+    "recompose": "^0.30.0",
     "storybook-chromatic": "^1.2.0",
     "styled-components": "^4.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-helmet": "^5.2.0",
     "react-lazyload": "^2.3.0",
     "react-popper": "^1.3.0",
+    "react-popper-tooltip": "^2.7.0",
     "storybook-chromatic": "^1.2.0",
     "styled-components": "^4.1.1"
   },

--- a/src/components/tooltip/Popper.stories.js
+++ b/src/components/tooltip/Popper.stories.js
@@ -1,59 +1,59 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { storiesOf } from '@storybook/react';
-import styled from 'styled-components';
+// /* eslint-disable import/no-extraneous-dependencies */
+// import React from 'react';
+// import PropTypes from 'prop-types';
+// import { storiesOf } from '@storybook/react';
+// import styled from 'styled-components';
 
-import { Manager, Target, PopperWithArrow } from './Popper';
+// import { Manager, Target, PopperWithArrow } from './Popper';
 
-const ViewPort = styled.div`
-  width: 350px;
-  height: 350px;
-  overflow: scroll;
-`;
+// const ViewPort = styled.div`
+//   width: 350px;
+//   height: 350px;
+//   overflow: scroll;
+// `;
 
-const BackgroundBox = styled.div`
-  width: 500px;
-  height: 500px;
-  background: #eee;
-  position: relative;
-  padding: 150px;
-`;
+// const BackgroundBox = styled.div`
+//   width: 500px;
+//   height: 500px;
+//   background: #eee;
+//   position: relative;
+//   padding: 150px;
+// `;
 
-const RedBox = styled.div`
-  width: 200px;
-  height: 100px;
-  background-color: red;
-  color: white;
-`;
+// const RedBox = styled.div`
+//   width: 200px;
+//   height: 100px;
+//   background-color: red;
+//   color: white;
+// `;
 
-const BlueBox = styled.div`
-  width: 100px;
-  height: 50px;
-  background-color: blue;
-  color: white;
-`;
+// const BlueBox = styled.div`
+//   width: 100px;
+//   height: 50px;
+//   background-color: blue;
+//   color: white;
+// `;
 
-const Story = ({ placement }) => (
-  <Manager>
-    <Target>
-      <RedBox />
-    </Target>
-    <PopperWithArrow placement={placement}>
-      <BlueBox>Tooltip!!</BlueBox>
-    </PopperWithArrow>
-  </Manager>
-);
+// const Story = ({ placement }) => (
+//   <Manager>
+//     <Target>
+//       <RedBox />
+//     </Target>
+//     <PopperWithArrow placement={placement}>
+//       <BlueBox>Tooltip!!</BlueBox>
+//     </PopperWithArrow>
+//   </Manager>
+// );
 
-Story.propTypes = { placement: PropTypes.string.isRequired };
+// Story.propTypes = { placement: PropTypes.string.isRequired };
 
-storiesOf('tooltip/Popper', module)
-  .addDecorator(storyFn => (
-    <ViewPort>
-      <BackgroundBox>{storyFn()}</BackgroundBox>
-    </ViewPort>
-  ))
-  .add('top', () => <Story placement="top" />);
-// .add('bottom', () => <Story placement="bottom" />)
-// .add('left', () => <Story placement="left" />)
-// .add('right', () => <Story placement="right" />);
+// storiesOf('tooltip/Popper', module)
+//   .addDecorator(storyFn => (
+//     <ViewPort>
+//       <BackgroundBox>{storyFn()}</BackgroundBox>
+//     </ViewPort>
+//   ))
+//   .add('top', () => <Story placement="top" />);
+// // .add('bottom', () => <Story placement="bottom" />)
+// // .add('left', () => <Story placement="left" />)
+// // .add('right', () => <Story placement="right" />);

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -1,0 +1,98 @@
+// Our wrapper around react-popper that does common stuff.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { typography } from './../../shared/styles';
+
+const ifPlacementEquals = (placement, value, fallback = 0) => props =>
+  props['data-placement'].split('-')[0] === placement ? value : fallback;
+
+const ArrowSpacing = 8;
+
+const Arrow = styled.div`
+  position: absolute;
+  border-style: solid;
+
+  margin-bottom: ${ifPlacementEquals('top', '0', ArrowSpacing)}px;
+  margin-top: ${ifPlacementEquals('bottom', '0', ArrowSpacing)}px;
+  margin-right: ${ifPlacementEquals('left', '0', ArrowSpacing)}px;
+  margin-left: ${ifPlacementEquals('right', '0', ArrowSpacing)}px;
+
+  bottom: ${ifPlacementEquals('top', ArrowSpacing * -1, 'auto')}px;
+  top: ${ifPlacementEquals('bottom', ArrowSpacing * -1, 'auto')}px;
+  right: ${ifPlacementEquals('left', ArrowSpacing * -1, 'auto')}px;
+  left: ${ifPlacementEquals('right', ArrowSpacing * -1, 'auto')}px;
+
+  border-bottom-width: ${ifPlacementEquals('top', '0', ArrowSpacing)}px;
+  border-top-width: ${ifPlacementEquals('bottom', '0', ArrowSpacing)}px;
+  border-right-width: ${ifPlacementEquals('left', '0', ArrowSpacing)}px;
+  border-left-width: ${ifPlacementEquals('right', '0', ArrowSpacing)}px;
+
+  border-top-color: ${ifPlacementEquals('top', 'white', 'transparent')};
+  border-bottom-color: ${ifPlacementEquals('bottom', 'white', 'transparent')};
+  border-left-color: ${ifPlacementEquals('left', 'white', 'transparent')};
+  border-right-color: ${ifPlacementEquals('right', 'white', 'transparent')};
+`;
+
+const TooltipWrapper = styled.div`
+  display: ${props => (props.hidden ? 'none' : 'inline-block')};
+  z-index: 2147483647;
+
+  ${props =>
+    !props.hasChrome &&
+    css`
+      margin-bottom: ${ifPlacementEquals('top', 8)}px;
+      margin-bottom: ${ifPlacementEquals('top-start', 8)}px;
+      margin-top: ${ifPlacementEquals('bottom', 8)}px;
+      margin-top: ${ifPlacementEquals('bottom-start', 8)}px;
+      margin-left: ${ifPlacementEquals('right', 8)}px;
+      margin-right: ${ifPlacementEquals('left', 8)}px;
+    `};
+
+  ${props =>
+    props.hasChrome &&
+    css`
+      margin-bottom: ${ifPlacementEquals('top', ArrowSpacing + 2)}px;
+      margin-top: ${ifPlacementEquals('bottom', ArrowSpacing + 2)}px;
+      margin-left: ${ifPlacementEquals('right', ArrowSpacing + 2)}px;
+      margin-right: ${ifPlacementEquals('left', ArrowSpacing + 2)}px;
+
+      background-image: linear-gradient(
+        -1deg,
+        rgba(248, 248, 248, 0.97) 0%,
+        rgba(255, 255, 255, 0.97) 100%
+      );
+      box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.05), 0 5px 15px 0 rgba(0, 0, 0, 0.1);
+      border-radius: 4px;
+      font-size: ${typography.size.s1}px;
+    `};
+`;
+
+export default function Tooltip({
+  placement,
+  hasChrome,
+  children,
+  arrowProps,
+  tooltipRef,
+  arrowRef,
+  ...props
+}) {
+  return (
+    <TooltipWrapper hasChrome={hasChrome} data-placement={placement} ref={tooltipRef} {...props}>
+      {hasChrome && <Arrow data-placement={placement} ref={arrowRef} {...arrowProps} />}
+      {children}
+    </TooltipWrapper>
+  );
+}
+
+Tooltip.propTypes = {
+  children: PropTypes.node.isRequired,
+  hasChrome: PropTypes.bool,
+  arrowProps: PropTypes.any,
+  placement: PropTypes.string,
+};
+Tooltip.defaultProps = {
+  hasChrome: true,
+  placement: 'top',
+};

--- a/src/components/tooltip/Tooltip.stories.js
+++ b/src/components/tooltip/Tooltip.stories.js
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Tooltip from './Tooltip';
+import styled from 'styled-components';
+
+// Popper would position the tooltip absolutely. We just need to make sure we are pos:rel
+const mockPopperProps = { style: { position: 'relative', top: '20px', left: '20px' } };
+
+const Content = styled.div`
+  width: 100px;
+  height: 100px;
+  font-size: 16px;
+  text-align: center;
+  line-height: 100px;
+  background: #eee;
+`;
+
+storiesOf('tooltip/Tooltip', module)
+  .add('basic, default', () => (
+    <Tooltip hasChrome {...mockPopperProps}>
+      <Content>Text</Content>
+    </Tooltip>
+  ))
+  .add('basic, default, bottom', () => (
+    <Tooltip hasChrome placement="bottom" {...mockPopperProps}>
+      <Content>Text</Content>
+    </Tooltip>
+  ))
+  .add('basic, default, left', () => (
+    <Tooltip hasChrome placement="left" {...mockPopperProps}>
+      <Content>Text</Content>
+    </Tooltip>
+  ))
+  .add('basic, default, right', () => (
+    <Tooltip placement="right" {...mockPopperProps}>
+      <Content>Text</Content>
+    </Tooltip>
+  ))
+  .add('no chrome', () => (
+    <Tooltip {...mockPopperProps}>
+      <Content>Text</Content>
+    </Tooltip>
+  ));

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-
 import TooltipTrigger from 'react-popper-tooltip';
+import { withState } from 'recompose';
+
+import Tooltip from './Tooltip';
 
 // A target that doesn't speak popper
 // prettier-ignore
@@ -16,41 +17,45 @@ const TargetSvgContainer = styled.g`
   cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
 `;
 
-export default function WithTooltip({ placement, trigger, tooltip, children }) {
+function WithTooltip({
+  svg,
+  trigger,
+  closeOnClick,
+  placement,
+  modifiers,
+  hasChrome,
+  tooltip,
+  children,
+  tooltipShown,
+  onVisibilityChange,
+}) {
+  const Container = svg ? TargetSvgContainer : TargetContainer;
   return (
     <TooltipTrigger
       placement={placement}
       trigger={trigger}
+      tooltipShown={tooltipShown}
+      onVisibilityChange={onVisibilityChange}
+      modifiers={modifiers}
       tooltip={({ getTooltipProps, getArrowProps, tooltipRef, arrowRef, placement }) => (
-        <div
-          {...getTooltipProps({
-            ref: tooltipRef,
-            className: 'tooltip-container',
-            /* your props here */
-          })}
+        <Tooltip
+          hasChrome={hasChrome}
+          placement={placement}
+          tooltipRef={tooltipRef}
+          arrowRef={arrowRef}
+          arrowProps={getArrowProps()}
+          {...getTooltipProps()}
         >
-          <div
-            {...getArrowProps({
-              ref: arrowRef,
-              'data-placement': placement,
-              className: 'tooltip-arrow',
-              /* your props here */
-            })}
-          />
-          {typeof tooltip === 'function' ? tooltip({ onHide: this.onHideImmediately }) : tooltip}
-        </div>
+          {typeof tooltip === 'function'
+            ? tooltip({ onHide: () => onVisibilityChange(false) })
+            : tooltip}
+        </Tooltip>
       )}
     >
       {({ getTriggerProps, triggerRef }) => (
-        <span
-          {...getTriggerProps({
-            ref: triggerRef,
-            className: 'trigger',
-            /* your props here */
-          })}
-        >
+        <Container ref={triggerRef} {...getTriggerProps()}>
           {children}
-        </span>
+        </Container>
       )}
     </TooltipTrigger>
   );
@@ -59,243 +64,25 @@ export default function WithTooltip({ placement, trigger, tooltip, children }) {
 WithTooltip.propTypes = {
   svg: PropTypes.bool,
   trigger: PropTypes.string,
-  startOpen: PropTypes.bool,
   closeOnClick: PropTypes.bool,
   placement: PropTypes.string,
   modifiers: PropTypes.shape({}),
-  children: PropTypes.node.isRequired,
   hasChrome: PropTypes.bool,
   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  children: PropTypes.node.isRequired,
+  tooltipShown: PropTypes.bool.isRequired,
+  onVisibilityChange: PropTypes.func.isRequired,
 };
 
 WithTooltip.defaultProps = {
   svg: false,
   trigger: 'hover',
-  startOpen: false,
   closeOnClick: false,
   placement: 'top',
   modifiers: {},
   hasChrome: true,
 };
 
-// function withinElements(element, elements) {
-//   return (
-//     !!elements.find(e => e === element) ||
-//     (element.parentNode && withinElements(element.parentNode, elements))
-//   );
-// }
-
-// class WithTooltip extends Component {
-//   constructor(props, context) {
-//     super(props, context);
-//     this.state = { hidden: !props.startOpen };
-//     this.onHideImmediately = this.onHideImmediately.bind(this);
-//     this.onHide = this.onHide.bind(this);
-//     this.onHideIfOutsideTooltip = this.onHideIfOutsideTooltip.bind(this);
-//     this.onHideIfOutsideTooltipOrCloseOnClick = this.onHideIfOutsideTooltipOrCloseOnClick.bind(
-//       this
-//     );
-//     this.onHideIfOutsideBody = this.onHideIfOutsideBody.bind(this);
-//     this.onShow = this.onShow.bind(this);
-//     this.onToggleHidden = this.onToggleHidden.bind(this);
-//   }
-
-//   componentDidMount() {
-//     if (!this.targetElement) {
-//       // Don't try and render the popper if we haven't actually rendered a DOM
-//       // element -- i.e we are testing
-//       return;
-//     }
-//     document.body.addEventListener('click', this.onHideIfOutsideTooltipOrCloseOnClick, false);
-//     // iOS doesn't fire click events unless you actually click on something (it seems).
-//     document.body.addEventListener('touchend', this.onHideIfOutsideTooltip, false);
-//     document.addEventListener('click', this.onHideIfOutsideBody, false);
-//     this.popper = document.createElement('div');
-//     this.popper.setAttribute('style', 'height:0; width: 0;');
-//     this.rootEl = document.getElementById('chromatic-root') || document.body;
-//     this.rootEl.appendChild(this.popper);
-//     this.renderPopper();
-
-//     if (!this.state.hidden && this.props.mode === 'hover') {
-//       this.timeout = setTimeout(() => this.onHideImmediately(), 1000);
-//     }
-//   }
-
-//   componentDidUpdate() {
-//     this.renderPopper();
-//   }
-
-//   componentWillUnmount() {
-//     document.body.removeEventListener('click', this.onHideIfOutsideTooltipOrCloseOnClick);
-//     document.body.removeEventListener('touchend', this.onHideIfOutsideTooltip);
-//     document.removeEventListener('click', this.onHideIfOutsideBody);
-//     unmountComponentAtNode(this.popper);
-//     this.rootEl.removeChild(this.popper);
-//     this.unmounted = true;
-//   }
-
-//   onHideImmediately() {
-//     if (!this.unmounted) {
-//       this.setState({ hidden: true });
-//     }
-//   }
-
-//   onHide() {
-//     if (this.props.mode === 'hover') {
-//       this.timeout = setTimeout(this.onHideImmediately, 50);
-//     } else {
-//       setTimeout(this.onHideImmediately, 0);
-//     }
-//   }
-
-//   onHideIfOutsideTooltip(event) {
-//     if (
-//       !this.state.hidden &&
-//       !withinElements(event.target, [this.targetElement, this.popperElement])
-//     ) {
-//       this.onHide();
-//     }
-//   }
-
-//   onHideIfOutsideTooltipOrCloseOnClick(event) {
-//     if (this.state.hidden) {
-//       return;
-//     }
-
-//     if (this.props.closeOnClick) {
-//       this.onHide();
-//     } else {
-//       this.onHideIfOutsideTooltip(event);
-//     }
-//   }
-
-//   onHideIfOutsideBody(event) {
-//     if (event.target === document.documentElement) {
-//       this.onHide();
-//     }
-//   }
-
-//   onShow() {
-//     clearTimeout(this.timeout);
-//     this.setState({ hidden: false });
-//   }
-
-//   onToggleHidden(event) {
-//     // We need to prevent default here because the events fire in different order on different platforms
-//     // On desktop, the react event fires *second* which means it can clear the "hide" timeouts
-//     // set by clicking anywhere when closeOnClick is set.
-//     // On mobile, the react event fires *first* (most of the time), so we can use preventDefault
-//     // to stop the hide events from firing.
-//     event.preventDefault();
-//     if (this.state.hidden) {
-//       this.onShow();
-//     } else {
-//       this.onHide();
-//     }
-//   }
-
-//   events() {
-//     const { mode } = this.props;
-//     if (mode === 'hover') {
-//       const events = {
-//         onMouseOver: this.onShow,
-//         onMouseOut: this.onHide,
-//       };
-//       return {
-//         targetEvents: events,
-//         popperEvents: events,
-//       };
-//     } else if (mode === 'click') {
-//       return {
-//         targetEvents: {
-//           onClick: this.onToggleHidden,
-//         },
-//         popperEvents: {},
-//       };
-//     }
-//     throw new Error(`Tooltip mode ${mode} not implemented`);
-//   }
-
-//   renderPopper() {
-//     const {
-//       svg,
-//       mode,
-//       closeOnClick,
-//       startOpen,
-//       placement,
-//       modifiers,
-//       children,
-//       hasChrome,
-//       tooltip,
-//       ...props
-//     } = this.props;
-//     const { hidden } = this.state;
-
-//     if (!hidden) {
-//       const managerElement = (
-//         <Manager {...props}>
-//           <Target mode={mode}>
-//             {({ targetProps: { ref } }) => ref(this.targetElement) || <div />}
-//           </Target>
-//           <PopperWithArrow
-//             innerRef={r => {
-//               this.popperElement = r;
-//             }}
-//             placement={placement}
-//             modifiers={modifiers}
-//             hidden={hidden}
-//             hasChrome={hasChrome}
-//             {...this.events().popperEvents}
-//           >
-//             {typeof tooltip === 'function' ? tooltip({ onHide: this.onHideImmediately }) : tooltip}
-//           </PopperWithArrow>
-//         </Manager>
-//       );
-
-//       render(managerElement, this.popper);
-//     } else {
-//       unmountComponentAtNode(this.popper);
-//     }
-//   }
-
-//   render() {
-//     const { svg, mode, placement, children, hasChrome, tooltip, ...props } = this.props;
-
-//     const Container = svg ? TargetSvgContainer : TargetContainer;
-//     return (
-//       <Container
-//         {...this.events().targetEvents}
-//         innerRef={r => {
-//           this.targetElement = r;
-//         }}
-//         mode={mode}
-//         {...props}
-//       >
-//         {this.props.children}
-//       </Container>
-//     );
-//   }
-// }
-// WithTooltip.propTypes = {
-//   svg: PropTypes.bool,
-//   mode: PropTypes.string,
-//   startOpen: PropTypes.bool,
-//   closeOnClick: PropTypes.bool,
-//   placement: PropTypes.string,
-//   modifiers: PropTypes.shape({}),
-//   children: PropTypes.node.isRequired,
-//   hasChrome: PropTypes.bool,
-//   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-// };
-
-// WithTooltip.defaultProps = {
-//   svg: false,
-//   mode: 'hover',
-//   startOpen: false,
-//   closeOnClick: false,
-//   placement: 'top',
-//   modifiers: {},
-//   hasChrome: true,
-// };
-
-// export default WithTooltip;
+export default withState('tooltipShown', 'onVisibilityChange', ({ startOpen }) => startOpen)(
+  WithTooltip
+);

--- a/src/components/tooltip/WithTooltip.stories.js
+++ b/src/components/tooltip/WithTooltip.stories.js
@@ -1,87 +1,87 @@
-// /* eslint-disable import/no-extraneous-dependencies */
-// import React from 'react';
-// import PropTypes from 'prop-types';
-// import { storiesOf } from '@storybook/react';
-// import styled from 'styled-components';
-//
-// import TooltipMessage from './TooltipMessage';
-// import WithTooltip from './WithTooltip';
-//
-// const ViewPort = styled.div`
-//   height: 300px;
-// `;
-//
-// const BackgroundBox = styled.div`
-//   width: 500px;
-//   height: 500px;
-//   overflow-y: scroll;
-//   background: #eee;
-//   position: relative;
-// `;
-//
-// const Spacer = styled.div`
-//   height: 100px;
-// `;
-//
-// const Trigger = styled.div`
-//   width: 200px;
-//   height: 100px;
-//   background-color: red;
-//   color: white;
-// `;
-//
-// const Tooltip = ({ onHide }) => (
-//   <TooltipMessage
-//     title="Lorem ipsum dolor sit"
-//     desc="Amet consectatur vestibulum concet durum politu coret weirom"
-//     links={[{ title: 'Continue', onClick: onHide }]}
-//   />
-// );
-//
-// Tooltip.propTypes = {
-//   onHide: PropTypes.func,
-// };
-//
-// Tooltip.defaultProps = {
-//   onHide: null,
-// };
-//
-// storiesOf('tooltip/WithTooltip', module)
-//   .addDecorator(storyFn => (
-//     <ViewPort>
-//       <BackgroundBox>
-//         <Spacer />
-//         {storyFn()}
-//       </BackgroundBox>
-//     </ViewPort>
-//   ))
-//   .add('simple hover', () => (
-//     <WithTooltip placement="top" mode="hover" tooltip={<Tooltip />}>
-//       <Trigger>Hover me!</Trigger>
-//     </WithTooltip>
-//   ))
-//   .add('simple hover, functional', () => (
-//     <WithTooltip placement="top" mode="hover" tooltip={Tooltip}>
-//       <Trigger>Hover me!</Trigger>
-//     </WithTooltip>
-//   ))
-//   .add('simple click', () => (
-//     <WithTooltip placement="top" mode="click" tooltip={<Tooltip />}>
-//       <Trigger>Click me!</Trigger>
-//     </WithTooltip>
-//   ))
-//   .add('simple click start open', () => (
-//     <WithTooltip placement="top" mode="click" startOpen tooltip={<Tooltip />}>
-//       <Trigger>Click me!</Trigger>
-//     </WithTooltip>
-//   ))
-//   .add('simple click closeOnClick', () => (
-//     <WithTooltip placement="top" mode="click" closeOnClick tooltip={<Tooltip />}>
-//       <Trigger>Click me!</Trigger>
-//     </WithTooltip>
-//   ))
-//   .add('no chrome', () => (
-//     <WithTooltip placement="top" mode="click" hasChrome={false} tooltip={<Tooltip />}>
-//       <Trigger>Click me!</Trigger>
-//     </WithTooltip>
-//   ));
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { storiesOf } from '@storybook/react';
+import styled from 'styled-components';
+
+import TooltipMessage from './TooltipMessage';
+import WithTooltip from './WithTooltip';
+
+const ViewPort = styled.div`
+  height: 300px;
+`;
+
+const BackgroundBox = styled.div`
+  width: 500px;
+  height: 500px;
+  overflow-y: scroll;
+  background: #eee;
+  position: relative;
+`;
+
+const Spacer = styled.div`
+  height: 100px;
+`;
+
+const Trigger = styled.div`
+  width: 200px;
+  height: 100px;
+  background-color: red;
+  color: white;
+`;
+
+const Tooltip = ({ onHide }) => (
+  <TooltipMessage
+    title="Lorem ipsum dolor sit"
+    desc="Amet consectatur vestibulum concet durum politu coret weirom"
+    links={[{ title: 'Continue', onClick: onHide }]}
+  />
+);
+
+Tooltip.propTypes = {
+  onHide: PropTypes.func,
+};
+
+Tooltip.defaultProps = {
+  onHide: null,
+};
+
+storiesOf('tooltip/WithTooltip', module)
+  .addDecorator(storyFn => (
+    <ViewPort>
+      <BackgroundBox>
+        <Spacer />
+        {storyFn()}
+      </BackgroundBox>
+    </ViewPort>
+  ))
+  .add('simple hover', () => (
+    <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />}>
+      <Trigger>Hover me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('simple hover, functional', () => (
+    <WithTooltip placement="top" trigger="hover" tooltip={Tooltip}>
+      <Trigger>Hover me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('simple click', () => (
+    <WithTooltip placement="top" trigger="click" tooltip={<Tooltip />}>
+      <Trigger>Click me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('simple click start open', () => (
+    <WithTooltip placement="top" trigger="click" startOpen tooltip={<Tooltip />}>
+      <Trigger>Click me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('simple click closeOnClick', () => (
+    <WithTooltip placement="top" trigger="click" closeOnClick tooltip={<Tooltip />}>
+      <Trigger>Click me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('no chrome', () => (
+    <WithTooltip placement="top" trigger="click" hasChrome={false} tooltip={<Tooltip />}>
+      <Trigger>Click me!</Trigger>
+    </WithTooltip>
+  ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,10 @@ chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -5064,7 +5068,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.14, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.14, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -6303,7 +6307,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -9748,6 +9752,12 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
+react-github-button@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/react-github-button/-/react-github-button-0.1.11.tgz#fc61e1f1e1371169d3618c1ba37306ba04081e56"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-helmet@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
@@ -9783,7 +9793,7 @@ react-lazyload@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.3.0.tgz#ccb134223012447074a96543954f44b055dc6185"
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -9998,6 +10008,17 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+recompose@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
 
 recursive-readdir@2.2.1:
   version "2.2.1"
@@ -11299,7 +11320,7 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.3, symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,13 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^16.1.0":
+  version "16.7.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.11.tgz#1743b82ea6a0c659467f0c7317c233edb1f10be9"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/tmp@^0.0.32":
   version "0.0.32"
   resolved "http://registry.npmjs.org/@types/tmp/-/tmp-0.0.32.tgz#0d3cb31022f8427ea58c008af32b80da126ca4e3"
@@ -9028,6 +9035,16 @@ pngquant-bin@^5.0.0:
     execa "^0.10.0"
     logalot "^2.0.0"
 
+polished@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-2.3.1.tgz#557ea07e5bcb1b9c7d71935a01d0315831234d48"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+popper.js@^1.14.4:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.6.tgz#ab20dd4edf9288b8b3b6531c47c361107b60b4b0"
+
 portfinder@^1.0.9:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.19.tgz#07e87914a55242dcda5b833d42f018d6875b595f"
@@ -9762,6 +9779,10 @@ react-is@^16.6.0:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
 
+react-lazyload@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.3.0.tgz#ccb134223012447074a96543954f44b055dc6185"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -9773,6 +9794,25 @@ react-modal@^3.6.1:
     exenv "^1.2.0"
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
+
+react-popper-tooltip@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-2.7.0.tgz#28c3b2853edafd69bf3601fadd6d8776d07ae226"
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    react-popper "^1.0.2"
+
+react-popper@^1.0.2, react-popper@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.0.tgz#e769199bbe1273611957892f9950ef1d42c3f7ce"
+  dependencies:
+    "@types/react" "^16.1.0"
+    babel-runtime "6.x.x"
+    create-react-context "^0.2.1"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.5"
     warning "^3.0.0"
 
 react-side-effect@^1.1.0:
@@ -11578,6 +11618,10 @@ type-is@~1.6.16:
 type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
+
+typed-styles@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
@domyen since we wrote the `WithTooltip` component (which uses popper directly), this library has appeared: https://www.npmjs.com/package/react-popper-tooltip

The library handles the low-level tooltip stuff like `trigger` (what we called `mode`, i.e. `click` vs `hover` etc).

It ships with some styles, but not the styles we want.

I'm thinking we refactor `WithTooltip` to:
 (a) use `react-popper-tooltip` behind the scenes
 (b) change the API to better reflect the underlying API (e.g. `mode` => `trigger`, `startOpen` => `defaultTooltipShown`)

What do you think?

Also do you think we should publish our styled-component-ed `WithTooltip` as a package on npm?