### PR TITLE
Add Root Attribute addon

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -290,6 +290,11 @@ export function PureAddonScreen({ data: { allMediumPost }, ...props }) {
           desc="Select between JSS themes."
           addonUrl="https://github.com/vertexbz/storybook-addon-jss-theme"
         />
+        <AddonItem
+          title="Root Attribute"
+          desc="Storybook addon, which provide ability to change html or body attribute."
+          addonUrl="https://github.com/le0pard/storybook-addon-root-attribute"
+        />
 
         <Subheader>Design</Subheader>
         <AddonItem

--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -292,7 +292,7 @@ export function PureAddonScreen({ data: { allMediumPost }, ...props }) {
         />
         <AddonItem
           title="Root Attribute"
-          desc="Storybook addon, which provide ability to change html or body attribute."
+          desc="Provides the ability to change the html or body attribute."
           addonUrl="https://github.com/le0pard/storybook-addon-root-attribute"
         />
 


### PR DESCRIPTION
This addon help to change html or body attribute in stories (can help, for example, if you are using `:root` CSS variables for themes)