### PR TITLE
Fix docs link on addons page

### DIFF
--- a/site-metadata.js
+++ b/site-metadata.js
@@ -85,6 +85,7 @@ const siteMetadata = {
       actions: `${gitHubOrg}/storybook/tree/master/addons/actions`,
       source: `${gitHubOrg}/storybook/tree/master/addons/storysource`,
       info: `${gitHubOrg}/storybook/tree/master/addons/info`,
+      notes: `${gitHubOrg}/storybook/tree/master/addons/notes`,
       viewport: `${gitHubOrg}/storybook/tree/master/addons/viewport`,
       storyshots: `${gitHubOrg}/storybook/tree/master/addons/storyshots`,
       backgrounds: `${gitHubOrg}/storybook/tree/master/addons/backgrounds`,

--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -124,9 +124,9 @@ export function PureAddonScreen({ data: { allMediumPost }, ...props }) {
         <AddonItem
           appearance="official"
           image={<img src={DocsSVG} alt="docs" />}
-          title="Docs"
+          title="Notes"
           desc="Document component usage and properties in Markdown"
-          addonUrl={officialAddons.info}
+          addonUrl={officialAddons.notes}
         />
         <AddonItem
           appearance="official"


### PR DESCRIPTION
Linking docs to addon-info is misleading. Setting it to Notes for now and we can update once Docs is live