### PR TITLE
Notes tile on Addons page now redirects to the proper link

### DIFF
--- a/src/components/lib/useSiteMetadata.js
+++ b/src/components/lib/useSiteMetadata.js
@@ -80,6 +80,7 @@ const useSiteMetadata = () => {
               source
               info
               viewport
+              notes
               storyshots
               backgrounds
               accessibility


### PR DESCRIPTION
This change is a result of the issue that was brought up on the storybook project by @fauverism. The link to the Notes tile on the Storybook Addons page was broken and did not lead anywhere. I identified that notes was missing from the useSiteMetadata file and thus the URL was not being pulled in. So, I added in "notes" to the officialAddons section.

Fixes https://github.com/storybooks/storybook/issues/6723