### PR TITLE
Fix Gatsby StaticQuery errors in Storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,7 @@
 module.exports = ({ config }) => {
+  // set the NODE_ENV to 'production' by default, to allow babel-plugin-remove-graphql-queries to remove static queries
+  process.env.NODE_ENV = 'production'
+  
   // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
   config.resolve.mainFields = ['browser', 'module', 'main'];
 

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "start-storybook -p 6006 -s static",
-    "build-storybook": "build-storybook -s static",
+    "storybook": "NODE_ENV=production start-storybook -p 6006 -s static",
+    "build-storybook": "NODE_ENV=production build-storybook -s static",
     "chromatic": "CHROMATIC_APP_CODE=dd2oqshntir chromatic test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "NODE_ENV=production start-storybook -p 6006 -s static",
-    "build-storybook": "NODE_ENV=production build-storybook -s static",
+    "storybook": "start-storybook -p 6006 -s static",
+    "build-storybook": "build-storybook -s static",
     "chromatic": "CHROMATIC_APP_CODE=dd2oqshntir chromatic test"
   },
   "devDependencies": {


### PR DESCRIPTION
PR for https://github.com/storybooks/frontpage/issues/43
Sets `NODE_ENV` to `production` for Storybook ~npm scripts~ webpack config.


https://github.com/storybooks/frontpage/issues/43#issuecomment-493798728